### PR TITLE
Foundry scaffold: integrity gate, lift pipeline, fence, meta-skill

### DIFF
--- a/.claude/skills/foundry/SKILL.md
+++ b/.claude/skills/foundry/SKILL.md
@@ -1,0 +1,71 @@
+---
+name: foundry
+description: The build-and-maintenance process for this repository's converged skill kit. Use for ANY convergence or maintenance work here — lifting files from upstream sources, building or revising one of the five skills, handling upstream drift or a failed integrity check, adding a contradiction ruling, distilling source material, installing the private course drop-in, or evaluating a new upstream or skill for the kit. Load BEFORE editing anything.
+metadata:
+  internal: "true"
+license: Apache-2.0
+---
+
+# Foundry
+
+This repo converges 84 upstream design-engineering skills into five
+(`design`, `build`, `review`, `product-description`, `brand-assets`), preserving the
+best source prose **byte-for-byte** and proving it with hashes. You are operating a
+factory with strict rules, not editing a normal repo. AGENTS.md is the fence; this
+skill is the manual.
+
+## Before anything else
+
+1. Read `foundry/MANIFEST.json` — look up the class of every file you intend to touch.
+2. Read `foundry/LEDGER.md` — rulings bind everything you author.
+3. Pick the runbook that matches the task (table below) and follow it exactly.
+4. End every session that changed provenance state with a `foundry/LOG.md` line and a
+   green `foundry/scripts/check-integrity.sh`.
+
+## File classes
+
+| Class | Meaning | Your permissions |
+| --- | --- | --- |
+| `verbatim` | Byte-for-byte lift from a pinned upstream commit | Never edit. Re-lift via script or nothing. |
+| `verbatim-minus` | Verbatim with a recorded cut (pristine + `.patch` in `foundry/pristine/`) | Never edit the file directly. Changing the cut = edit file, run `make-patch.sh`, PR shows the patch diff. |
+| `distilled` | Authored condensation of recorded sources; the salvage list in its derivation file is the contract | Edit only via the distill-refresh runbook; finish with `check-integrity.sh --update-distilled <path>`. |
+| `authored` | Ours: spines, glue, foundry docs | Edit freely, subject to the ledger and the anti-slop gates. |
+
+`private: true` entries are course drop-in files — purchased content that exists only on
+local machines, never in a commit.
+
+## The convergence method (for building or revising a skill)
+
+- **Architecture:** each skill is a thin authored **spine** (router: modes, cues,
+  contract, rulings block; target < 150 lines) over **references** lifted verbatim from
+  graded sources. New prose is written only for glue, routing, and rulings.
+- **Grades bind handling:** GOLD → lift verbatim, never reword (cut whole sections only,
+  via verbatim-minus, logged) · SOLID → lift, dedupe only · PADDED → distill against a
+  named salvage list · SLOP → exclude.
+- **Anti-slop gates on anything you author:** no restatement between spine and
+  references (principle in the spine, recipe in the ref, never both) · every sentence
+  must change an implementation choice · no adjective stacks, personas, or dial theater ·
+  skill activation load stays under ~500 lines.
+- **Plan first:** write `foundry/derivations/<skill>.md` (sources, classes, cuts,
+  rulings applied) before running a single lift. The receipts precede the work.
+- **Verify:** `check-integrity.sh` green, `skills-ref validate` (or equivalent) clean,
+  spine checked against every ledger ruling it touches.
+
+## Runbooks
+
+| Task | Runbook |
+| --- | --- |
+| Bring a file in from an upstream | `runbooks/lift.md` |
+| An upstream changed a vendored file | `runbooks/re-lift.md` |
+| A distilled file's source changed, or the distillation needs work | `runbooks/distill-refresh.md` |
+| Sources contradict, or a ruling needs to change | `runbooks/new-ruling.md` |
+| CI integrity check is red | `runbooks/integrity-failure.md` |
+| Install/refresh the purchased course files locally | `runbooks/course-dropin.md` |
+| Evaluate a new upstream or add a skill to the kit | `runbooks/new-skill.md` |
+
+## Division of labor — never blur it
+
+**LLMs propose** (grade, classify drift, author spines, draft PRs) ·
+**hashes verify** (`check-integrity.sh`, in CI on every push) ·
+**humans merge** (nothing you produce lands on main without review).
+Your token stream is never the channel vendored prose travels through.

--- a/.claude/skills/foundry/runbooks/course-dropin.md
+++ b/.claude/skills/foundry/runbooks/course-dropin.md
@@ -1,0 +1,14 @@
+# Runbook: course drop-in — purchased content, local machines only
+
+The animations.dev pack is purchased and unlicensed for redistribution. It NEVER
+enters a commit. The public skills work without it and prefer it when present.
+
+1. Install/refresh locally:
+   `COURSE_SRC=~/oss/backnotprop/design/animationsdev foundry/scripts/course-dropin.sh`
+   First run on a machine that owns the pack: add `--record` to store private hashes.
+2. Quarterly: re-install the pack from the course, diff one agent dir (the 8 copies
+   are identical), re-run with `--record` if the course updated. LOG it.
+3. Adding a new mapping: create the manifest entry by hand (class as its grade,
+   `"private": true`, upstream `animationsdev`, upstream_path relative to the pack),
+   then run the script. The .gitignore fence must stay intact — the script refuses
+   to run without it.

--- a/.claude/skills/foundry/runbooks/distill-refresh.md
+++ b/.claude/skills/foundry/runbooks/distill-refresh.md
@@ -1,0 +1,11 @@
+# Runbook: distill refresh — regenerate a distilled file
+
+The salvage list in `foundry/derivations/<skill>.md` is the contract: it names
+exactly what the distillation must carry. Never regenerate without it in context.
+
+1. Read the derivation entry and the upstream diff (if drift triggered this).
+2. Update the recorded source pin: `lift.sh --class distilled-source` with the new SHA
+   (records provenance without copying bytes).
+3. Rewrite the distilled file against the salvage list. Anti-slop gates apply.
+4. Lock the new hash: `foundry/scripts/check-integrity.sh --update-distilled <path>`.
+5. PR: the reviewable diff is the distillation change itself. Human merges.

--- a/.claude/skills/foundry/runbooks/integrity-failure.md
+++ b/.claude/skills/foundry/runbooks/integrity-failure.md
@@ -1,0 +1,12 @@
+# Runbook: integrity failure — CI is red on hashes
+
+Someone or some agent edited a locked file. The diff shows exactly what changed.
+
+1. REVERT FIRST. Restore the file: for verbatim, re-run lift.sh at the recorded
+   pin (or `git checkout` the last green commit of that file); for verbatim-minus,
+   restore pristine+patch state. Never "accept the improvement" in place.
+2. If the edit was actually a good idea, re-route it to where improvements live:
+   a ledger ruling (we now disagree with the source), or a PR to the upstream
+   author (the source has a bug). Our copies stay mirrors.
+3. LOG the incident (`integrity-failure`): what changed, who/what changed it,
+   which runbook should have been used.

--- a/.claude/skills/foundry/runbooks/lift.md
+++ b/.claude/skills/foundry/runbooks/lift.md
@@ -1,0 +1,24 @@
+# Runbook: lift — bytes enter the repo
+
+Use when a file from a graded upstream becomes part of a skill.
+
+1. Confirm the file's grade and destination in `foundry/derivations/<skill>.md`
+   (write the derivation entry first if it doesn't exist).
+2. Run the script — never copy content any other way:
+   ```
+   foundry/scripts/lift.sh --upstream <id> --path <upstream-path> \
+     --dest skills/<skill>/references/<name>.md --skill <skill> \
+     [--sha <commit>] [--class verbatim|verbatim-minus]
+   ```
+   Omitting `--sha` pins to the upstream's current HEAD.
+3. For `verbatim-minus`: the script stores the pristine copy and an empty patch.
+   Now make the cut — edit the SHIPPED file (this is the one sanctioned edit,
+   the cut must match the derivation file's stated omissions), then:
+   ```
+   foundry/scripts/make-patch.sh skills/<skill>/references/<name>.md
+   ```
+4. Run `foundry/scripts/check-integrity.sh` — must be green.
+5. The script already appended the LOG line. PR it.
+
+FORBIDDEN: pasting file content through an editor or model output; lifting a file
+not named in a derivation entry; lifting from an upstream not in MANIFEST.

--- a/.claude/skills/foundry/runbooks/new-ruling.md
+++ b/.claude/skills/foundry/runbooks/new-ruling.md
@@ -1,0 +1,12 @@
+# Runbook: new ruling — sources contradict, or a ruling must change
+
+1. Write the entry in `foundry/LEDGER.md` with the next L-nn id: topic, positions
+   with short quotes, ruling, rationale. A changed ruling is a NEW entry marked
+   "supersedes L-nn" — never edit the old one.
+2. Add the ruling id to the `rulings` array of each affected manifest entry.
+3. Apply consequences in the same PR: authored spines edited directly; cuts to
+   vendored text via the verbatim-minus patch flow (edit + make-patch.sh).
+4. LOG line (`ruling`), integrity green, PR.
+
+Resolution order: measured evidence beats assertion · exact enforceable value beats
+a range · domain owner wins per the ownership matrix · ties get decided and logged.

--- a/.claude/skills/foundry/runbooks/new-skill.md
+++ b/.claude/skills/foundry/runbooks/new-skill.md
@@ -1,0 +1,15 @@
+# Runbook: new skill or upstream — the kit grows the way it was born
+
+Never vendor on vibes. The pipeline that built the kit applies to every addition:
+
+1. INVENTORY — what does the candidate contain (files, sizes, license, remote)?
+2. GRADE — full read, quoted evidence, GOLD/SOLID/PADDED/SLOP per file. Author
+   reputation buys a careful read, not a pass.
+3. MAP — overlap and contradictions against the existing five and the LEDGER.
+   Identical → keep better copy. Supplement → candidate for lifting. Contradict →
+   new-ruling runbook before anything is lifted.
+4. DECIDE — in / folded as references / distilled / cut. Record the decision and
+   salvage lists in `foundry/derivations/<skill>.md`.
+5. INTEGRATE — add the upstream to MANIFEST (with license), lift via the runbook,
+   update the skill spine's routing if a new mode appears.
+6. Register the upstream in the watcher matrix once it exists.

--- a/.claude/skills/foundry/runbooks/re-lift.md
+++ b/.claude/skills/foundry/runbooks/re-lift.md
@@ -1,0 +1,14 @@
+# Runbook: re-lift — an upstream changed a vendored file
+
+Usually triggered by an upstream-watch PR/issue; also valid manually.
+
+1. Check the LEDGER first: if the upstream change conflicts with an active ruling
+   (e.g. an exact value we ruled on), STOP — this is a new-ruling situation, not a
+   re-lift. Open an adjudicate issue.
+2. Re-run lift.sh with the same dest and the new `--sha`. It overwrites the file,
+   updates the manifest pin and hash, and logs.
+3. For verbatim-minus files: after the re-lift, re-apply the cut (edit + make-patch.sh).
+   If the patch no longer makes sense against the new text, that's a derivation
+   update — record it.
+4. Review the upstream diff in the PR like a dependency bump. Merge only with a
+   human's approval.

--- a/.github/workflows/integrity.yml
+++ b/.github/workflows/integrity.yml
@@ -1,0 +1,17 @@
+name: integrity
+# The gate. Recomputes every vendored file's hash against foundry/MANIFEST.json,
+# re-applies every verbatim-minus patch against its pristine copy, and verifies
+# coverage (no unclassified file under skills/*/references/). Any drift — one
+# reworded character in a byte-for-byte file — fails the build. See AGENTS.md.
+on:
+  push:
+  pull_request:
+jobs:
+  check:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Verify vendored-file integrity
+        run: |
+          chmod +x foundry/scripts/check-integrity.sh
+          foundry/scripts/check-integrity.sh

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,9 @@
+# foundry: local clone cache for lift.sh — never committed
+.foundry-cache/
+
+# foundry: private course drop-in (purchased animations.dev content — NEVER commit).
+# The README inside each course folder is the one tracked exception.
+skills/*/references/course/*
+!skills/*/references/course/README.md
+
+.DS_Store

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,34 @@
+# AGENTS.md — the fence
+
+This repository vendors other authors' writing **byte-for-byte** and proves it with
+hashes. Most files here are not editable, even to fix a typo. Before touching ANY
+file, look it up in `foundry/MANIFEST.json`.
+
+## The five rules
+
+1. **Never retype vendored content.** Bytes enter this repo only through
+   `foundry/scripts/lift.sh`. If you find yourself reproducing text from an upstream
+   repo in your own output, stop — run the script instead.
+2. **Locked files are never edited.** Classes `verbatim`, `verbatim-minus`, and
+   `distilled` are hash-locked; CI fails on one changed character. If a change seems
+   needed, propose it: a re-lift (upstream changed), a ledger ruling (we disagree with
+   the content), or an upstream PR (the content has a bug). Never edit in place.
+3. **Every change is a logged event.** Append one line to `foundry/LOG.md` for any
+   provenance-changing action. Scripts log their own actions. Never edit existing lines.
+4. **Upstream drift is classified, never auto-merged.** You may draft re-lift PRs and
+   drift issues; only a human merges. See the runbooks.
+5. **The ledger is law.** `foundry/LEDGER.md` holds the contradiction rulings (L-01…).
+   No text you author may contradict an active ruling. Changing a ruling is a new
+   superseding entry, never a silent edit.
+
+## Where the full process lives
+
+The foundry skill — `.claude/skills/foundry/SKILL.md` — carries the methodology
+(grading, spine + byte-preserved references, anti-slop gates) and seven runbooks
+(lift, re-lift, distill refresh, new ruling, integrity failure, course drop-in,
+new skill/upstream). Load it before doing any convergence or maintenance work.
+
+Verify before any PR: `foundry/scripts/check-integrity.sh` must pass.
+
+Never commit anything under `skills/*/references/course/` — purchased content,
+gitignored by design.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,1 @@
+@AGENTS.md

--- a/foundry/LEDGER.md
+++ b/foundry/LEDGER.md
@@ -1,0 +1,44 @@
+# Ledger — contradiction rulings
+
+Where graded sources disagree, we rule once and every skill follows the ruling. A ruling
+changes only by a new entry that supersedes it (never by silent edit). No skill text —
+authored or vendored-with-patch — may contradict an active ruling. Resolution order used
+throughout: measured evidence beats assertion · an exact enforceable value beats a range ·
+the domain owner wins per the ownership matrix · ties get a decision anyway, logged.
+
+Format: id · topic · positions · ruling · rationale. `Affects` lists repo files once they exist.
+
+---
+
+**L-01 · Press scale** — jakubkrehel: exactly `0.96` vs emilkowalski: `0.95–0.98` range.
+**Ruling:** 0.96 exact. An exact value is enforceable; a range invites drift. Emil's range noted as tolerance.
+
+**L-02 · Spring bounce** — jakubkrehel: always `0` vs emilkowalski: subtle `0.1–0.3` when used.
+**Ruling:** bounce 0 by default; nonzero only when the design direction's register explicitly calls for playful.
+
+**L-03 · Reduced motion** — emil monolith: gentler-not-zero, keep opacity/color vs animationsdev refs: disable all, no exceptions.
+**Ruling:** gentler-not-zero. Matches the two-variant doctrine; blanket disable is the lazier reading.
+
+**L-04 · Exit easing** — jakubkrehel + emil monolith: ease-out both directions vs emil design-rules: accelerate away (ease-in).
+**Ruling:** ease-out for exits by default. Two of three sources, including Emil against himself. Accelerate-away allowed as a deliberate, stated choice.
+
+**L-05 · will-change** — animationsdev: apply proactively vs jakubkrehel: only on observed first-frame stutter vs ibelick baseline: never outside an active animation.
+**Ruling:** reactive (jakub) — evidence-driven application only. Baseline's phrasing survives as the generation guardrail.
+
+**L-06 · Custom easing curves** — emilkowalski: "built-ins are too weak" vs ibelick baseline: "never introduce custom curves."
+**Ruling:** split by intent. Custom curves from the kit's named set: yes. Inventing novel curves ad hoc: no.
+
+**L-07 · Stagger** — emilkowalski: 30–80ms per item vs jakubkrehel: ~100ms per group.
+**Ruling:** both — the units differ (list items vs semantic chunks). Reconciled in one paragraph; not a conflict.
+
+**L-08 · Disabled submit buttons** — ibelick: explain why disabled vs jakubkrehel: never disable; validate on submit.
+**Ruling:** never disable. Wins on accessibility evidence — an enabled button that validates is discoverable; a disabled one is a dead end.
+
+**L-09 · Accessibility findings in audits** — ibelick improve-ui: "discard a11y findings unless requested" vs every other source.
+**Ruling:** a11y findings are never discarded. improve-ui's falsification pass survives without its discard rule.
+
+**L-10 · Motion by default** — leonxlnx gpt-taste/soft-skill: "static is forbidden" vs design-artifact + taste v2: motion must be motivated.
+**Ruling:** motivated motion. "If you cannot articulate the reason in one sentence, drop the animation." Mandated-motion texts were cut or stripped.
+
+**L-11 · Guidelines house taste** — vercel web-interface-guidelines: Title Case headings, "&" over "and", autocomplete stated both ways vs jakubkrehel: "evidence, not taste."
+**Ruling:** the evidence bar. House-taste rows are cut from the vendored copy (via its patch); the autocomplete tension resolves to: autocomplete on purposeful fields, off only for non-auth-sensitive cases.

--- a/foundry/LOG.md
+++ b/foundry/LOG.md
@@ -1,0 +1,12 @@
+# Log — append-only
+
+Every event that changes this repository's provenance state gets one line here:
+lift · re-lift · make-patch · distill-update · ruling · drift · integrity-failure ·
+course-dropin. Scripts append their own lines; humans and agents append lines for
+manual events. Never edit or delete existing lines.
+
+---
+
+- 2026-08-25 · genesis · ramos · repo renamed ui-skills → product-engineering; convergence target per the Moneyball Roster (84 source skills → 5: design, build, review, product-description, brand-assets)
+- 2026-08-25 · scaffold · claude+ramos · foundry created: MANIFEST, LEDGER (11 rulings seeded), scripts (lift, check-integrity, make-patch, course-dropin), integrity CI, fence (AGENTS.md/CLAUDE.md), foundry meta-skill
+- 2026-08-25 · note · claude · legacy skills/ (project-context, ui-review, ui-polish, ui-harden, ui-onboarding) remain live for consumers until each is superseded by the new five; their reference files are registered as class=authored

--- a/foundry/MANIFEST.json
+++ b/foundry/MANIFEST.json
@@ -1,0 +1,87 @@
+{
+  "manifest_version": 1,
+  "comment": "Source of truth for file provenance and integrity. Every file under skills/*/references/ must have an entry. Classes: verbatim (hash-locked lift), verbatim-minus (pristine + patch), distilled (authored from recorded sources), authored (ours). Managed by foundry/scripts/lift.sh \u2014 do not hand-edit entries for verbatim files.",
+  "upstreams": {
+    "emilkowalski/skills": {
+      "url": "https://github.com/emilkowalski/skills.git",
+      "license": "MIT"
+    },
+    "jakubkrehel/skills": {
+      "url": "https://github.com/jakubkrehel/skills.git",
+      "license": "MIT"
+    },
+    "ibelick/ui-skills": {
+      "url": "https://github.com/ibelick/ui-skills.git",
+      "license": "MIT"
+    },
+    "plannotator/effective-html": {
+      "url": "https://github.com/plannotator/effective-html.git",
+      "license": "MIT"
+    },
+    "vercel-labs/web-interface-guidelines": {
+      "url": "https://github.com/vercel-labs/web-interface-guidelines.git",
+      "license": "MIT"
+    },
+    "vercel-labs/agent-skills": {
+      "url": "https://github.com/vercel-labs/agent-skills.git",
+      "license": "MIT"
+    },
+    "steveruizok/product-description": {
+      "url": "https://gist.github.com/83ae5c53f2784ebf8f5fe0a3fb94480f.git",
+      "license": "permission-granted",
+      "license_note": "No license file; author granted reuse permission via Twitter \u2014 see NOTICE."
+    },
+    "animationsdev": {
+      "url": null,
+      "license": "UNLICENSED-PRIVATE",
+      "license_note": "Purchased course pack. No remote. Files never enter this repository; private drop-in only (class private)."
+    }
+  },
+  "files": {
+    "skills/project-context/references/design-format.md": {
+      "class": "authored",
+      "skill": "project-context",
+      "note": "legacy ui-skills reference (Impeccable-derived, ours) \u2014 carries into the new five"
+    },
+    "skills/project-context/references/templates.md": {
+      "class": "authored",
+      "skill": "project-context",
+      "note": "legacy ui-skills reference (Impeccable-derived, ours) \u2014 carries into the new five"
+    },
+    "skills/ui-harden/references/adaptation-patterns.md": {
+      "class": "authored",
+      "skill": "ui-harden",
+      "note": "legacy ui-skills reference (Impeccable-derived, ours) \u2014 carries into the new five"
+    },
+    "skills/ui-harden/references/performance-diagnostics.md": {
+      "class": "authored",
+      "skill": "ui-harden",
+      "note": "legacy ui-skills reference (Impeccable-derived, ours) \u2014 carries into the new five"
+    },
+    "skills/ui-harden/references/resilience-matrix.md": {
+      "class": "authored",
+      "skill": "ui-harden",
+      "note": "legacy ui-skills reference (Impeccable-derived, ours) \u2014 carries into the new five"
+    },
+    "skills/ui-onboarding/references/onboarding-patterns.md": {
+      "class": "authored",
+      "skill": "ui-onboarding",
+      "note": "legacy ui-skills reference (Impeccable-derived, ours) \u2014 carries into the new five"
+    },
+    "skills/ui-polish/references/polish-lenses.md": {
+      "class": "authored",
+      "skill": "ui-polish",
+      "note": "legacy ui-skills reference (Impeccable-derived, ours) \u2014 carries into the new five"
+    },
+    "skills/ui-review/references/experience-rubric.md": {
+      "class": "authored",
+      "skill": "ui-review",
+      "note": "legacy ui-skills reference (Impeccable-derived, ours) \u2014 carries into the new five"
+    },
+    "skills/ui-review/references/technical-rubric.md": {
+      "class": "authored",
+      "skill": "ui-review",
+      "note": "legacy ui-skills reference (Impeccable-derived, ours) \u2014 carries into the new five"
+    }
+  }
+}

--- a/foundry/derivations/README.md
+++ b/foundry/derivations/README.md
@@ -1,0 +1,7 @@
+# Derivations — per-skill receipts
+
+One file per skill, written BEFORE its lifts run. Each records: the sources
+(upstream + path + grade), the class each file enters as, every cut (for
+verbatim-minus), every salvage list (the contract for distilled files), and the
+ledger rulings applied. The full adjudication record that produced the roster
+lives in the project artifacts; these files are the buildable subset.

--- a/foundry/scripts/check-integrity.sh
+++ b/foundry/scripts/check-integrity.sh
@@ -1,0 +1,95 @@
+#!/usr/bin/env bash
+# check-integrity.sh — the gate. Fails (nonzero) if any vendored byte drifted.
+#
+# Checks, per foundry/MANIFEST.json:
+#   verbatim        sha256(file) must equal the recorded hash
+#   verbatim-minus  patch applied to the pristine copy must reproduce the file,
+#                   AND sha256(file) must equal the recorded hash
+#   distilled       sha256(file) must equal the recorded hash (updated only via
+#                   the distill runbook: --update-distilled <path>)
+#   authored        no hash check
+#   private: true   skipped when absent (course drop-in); verified when present
+# Coverage: every file under skills/*/references/ must have a manifest entry.
+#
+# Usage: foundry/scripts/check-integrity.sh [--update-distilled <repo-path>]
+set -euo pipefail
+REPO_ROOT="$(git -C "$(dirname "$0")" rev-parse --show-toplevel)"
+export REPO_ROOT
+exec python3 - "$@" <<'PYEOF'
+import hashlib, json, os, subprocess, sys, tempfile
+from datetime import date
+
+ROOT = os.environ["REPO_ROOT"]
+MANIFEST = os.environ.get("FOUNDRY_MANIFEST", os.path.join(ROOT, "foundry", "MANIFEST.json"))
+LOG = os.path.join(os.path.dirname(MANIFEST), "LOG.md")
+manifest = json.load(open(MANIFEST))
+files = manifest["files"]
+
+def sha256(path):
+    h = hashlib.sha256()
+    with open(path, "rb") as f:
+        for chunk in iter(lambda: f.read(1 << 16), b""): h.update(chunk)
+    return h.hexdigest()
+
+# --- deliberate distilled update (the distill runbook's final step) ---
+if len(sys.argv) == 3 and sys.argv[1] == "--update-distilled":
+    p = sys.argv[2]
+    e = files.get(p) or sys.exit(f"integrity: no manifest entry for {p}")
+    if e["class"] != "distilled": sys.exit(f"integrity: {p} is class {e['class']}, not distilled")
+    e["sha256"] = sha256(os.path.join(ROOT, p)); e["updated"] = date.today().isoformat()
+    json.dump(manifest, open(MANIFEST, "w"), indent=2); open(MANIFEST, "a").write("\n")
+    with open(LOG, "a") as f:
+        f.write(f"- {date.today().isoformat()} · distill-update · {os.environ.get('USER','unknown')} · {p} · sha256={e['sha256'][:12]}…\n")
+    print(f"integrity: distilled hash updated for {p}"); sys.exit(0)
+
+failures = []
+
+for path, e in sorted(files.items()):
+    abs_path = os.path.join(ROOT, path)
+    cls = e["class"]
+    if not os.path.exists(abs_path):
+        if e.get("private"): continue                    # drop-in not installed here
+        failures.append(f"MISSING   {path} (class {cls})"); continue
+    if cls == "authored": continue
+    if "sha256" in e:
+        actual = sha256(abs_path)
+        if actual != e["sha256"]:
+            failures.append(f"DRIFT     {path} (class {cls})\n"
+                            f"            expected {e['sha256']}\n"
+                            f"            actual   {actual}\n"
+                            f"            Locked file changed. Revert it, or use the re-lift/distill runbook.")
+    elif cls == "distilled":
+        failures.append(f"NO-HASH   {path} — distilled entry missing sha256; run --update-distilled after authoring")
+    if cls == "verbatim-minus":
+        pristine = os.path.join(ROOT, e["pristine"]); patch = os.path.join(ROOT, e["patch"])
+        if not (os.path.exists(pristine) and os.path.exists(patch)):
+            failures.append(f"NO-BASE   {path} — pristine or patch file missing"); continue
+        with tempfile.TemporaryDirectory() as td:
+            work = os.path.join(td, "work")
+            with open(pristine, "rb") as s, open(work, "wb") as d: d.write(s.read())
+            if os.path.getsize(patch) > 0:
+                r = subprocess.run(["patch", "--quiet", "--posix", work, patch], capture_output=True)
+                if r.returncode != 0:
+                    failures.append(f"BAD-PATCH {path} — patch does not apply cleanly to pristine"); continue
+            if sha256(work) != sha256(abs_path):
+                failures.append(f"PATCH-DRIFT {path} — pristine+patch does not reproduce the shipped file")
+
+# --- coverage: nothing under references/ escapes classification ---
+skills_dir = os.path.join(ROOT, "skills")
+if os.path.isdir(skills_dir):
+    for dirpath, _, names in os.walk(skills_dir):
+        for n in names:
+            rel = os.path.relpath(os.path.join(dirpath, n), ROOT)
+            parts = rel.split(os.sep)
+            if len(parts) >= 3 and parts[2] == "references" and rel not in files:
+                if n == "README.md" and "course" in parts: continue   # drop-in folder README
+                failures.append(f"UNTRACKED {rel} — every references/ file needs a manifest entry (authored counts)")
+
+if failures:
+    print("integrity: FAIL\n")
+    print("\n".join("  " + f for f in failures))
+    print(f"\n  {len(failures)} problem(s). Locked files are never edited in place —")
+    print("  see .claude/skills/foundry/runbooks/integrity-failure.md")
+    sys.exit(1)
+print(f"integrity: OK · {len(files)} tracked file(s) verified")
+PYEOF

--- a/foundry/scripts/course-dropin.sh
+++ b/foundry/scripts/course-dropin.sh
@@ -1,0 +1,57 @@
+#!/usr/bin/env bash
+# course-dropin.sh — LOCAL MACHINES ONLY. Fills the gitignored references/course/
+# folders from a purchased animations.dev skill pack install. Nothing this script
+# touches may ever be committed; the paths it writes to are gitignored, and
+# check-integrity.sh verifies the ignore rules are intact.
+#
+# Usage:
+#   COURSE_SRC=~/oss/backnotprop/design/animationsdev foundry/scripts/course-dropin.sh [--record]
+#
+#   --record   first run on a machine that owns the pack: store private hashes in
+#              the manifest so later runs (and integrity checks) verify the copies.
+#
+# Mappings live in MANIFEST.json as entries with "private": true and
+# "upstream": "animationsdev"; upstream_path is relative to $COURSE_SRC.
+set -euo pipefail
+REPO_ROOT="$(git -C "$(dirname "$0")" rev-parse --show-toplevel)"
+export REPO_ROOT
+exec python3 - "$@" <<'PYEOF'
+import hashlib, json, os, shutil, sys
+from datetime import date
+ROOT = os.environ["REPO_ROOT"]
+SRC = os.path.expanduser(os.environ.get("COURSE_SRC", "~/oss/backnotprop/design/animationsdev"))
+MANIFEST = os.environ.get("FOUNDRY_MANIFEST", os.path.join(ROOT, "foundry", "MANIFEST.json"))
+LOG = os.path.join(os.path.dirname(MANIFEST), "LOG.md")
+record = "--record" in sys.argv
+manifest = json.load(open(MANIFEST))
+
+def sha256(p):
+    h = hashlib.sha256()
+    with open(p, "rb") as f:
+        for c in iter(lambda: f.read(1 << 16), b""): h.update(c)
+    return h.hexdigest()
+
+# refuse to run if the ignore fence is missing
+gi = open(os.path.join(ROOT, ".gitignore")).read() if os.path.exists(os.path.join(ROOT, ".gitignore")) else ""
+if "references/course/" not in gi:
+    sys.exit("course-dropin: REFUSING — .gitignore does not fence references/course/")
+
+n = 0
+for path, e in manifest["files"].items():
+    if not e.get("private") or e.get("upstream") != "animationsdev": continue
+    src = os.path.join(SRC, e["upstream_path"]); dst = os.path.join(ROOT, path)
+    if not os.path.exists(src): print(f"course-dropin: skip (not in pack): {e['upstream_path']}"); continue
+    os.makedirs(os.path.dirname(dst), exist_ok=True); shutil.copyfile(src, dst)
+    h = sha256(dst)
+    if record:
+        e["sha256"] = h; e["lifted"] = date.today().isoformat()
+    elif e.get("sha256") and e["sha256"] != h:
+        print(f"course-dropin: WARNING — {path} differs from recorded hash (course updated?). "
+              f"Re-run with --record after confirming.", file=sys.stderr)
+    n += 1
+if record:
+    json.dump(manifest, open(MANIFEST, "w"), indent=2); open(MANIFEST, "a").write("\n")
+    with open(LOG, "a") as f:
+        f.write(f"- {date.today().isoformat()} · course-dropin --record · {os.environ.get('USER','unknown')} · {n} file(s)\n")
+print(f"course-dropin: {n} file(s) installed locally from {SRC}")
+PYEOF

--- a/foundry/scripts/lift.sh
+++ b/foundry/scripts/lift.sh
@@ -1,0 +1,102 @@
+#!/usr/bin/env bash
+# lift.sh — the ONLY way vendored bytes enter this repository.
+#
+# Copies a file from a pinned upstream commit into the repo, records provenance
+# (upstream, path, commit SHA, sha256) in foundry/MANIFEST.json, and appends a
+# LOG.md entry. LLM agents must never retype vendored content; they call this.
+#
+# Usage:
+#   foundry/scripts/lift.sh --upstream <id> --path <upstream-path> --dest <repo-path> \
+#       --skill <skill> [--sha <commit|HEAD>] [--class verbatim|verbatim-minus|distilled-source] \
+#       [--actor <name>] [--dry-run]
+#
+#   --upstream   key in MANIFEST.json "upstreams"
+#   --sha        upstream commit to lift from (default: HEAD of default branch)
+#   --class      verbatim (default) | verbatim-minus (also stores a pristine copy;
+#                author the cut afterwards with make-patch.sh) | distilled-source
+#                (records the source for a distilled file WITHOUT copying bytes)
+#   --dry-run    print what would happen, change nothing
+#
+# Env: FOUNDRY_MANIFEST overrides the manifest path (used by tests).
+set -euo pipefail
+REPO_ROOT="$(git -C "$(dirname "$0")" rev-parse --show-toplevel)"
+export REPO_ROOT
+exec python3 - "$@" <<'PYEOF'
+import hashlib, json, os, re, subprocess, sys
+from datetime import date
+
+ROOT = os.environ["REPO_ROOT"]
+MANIFEST = os.environ.get("FOUNDRY_MANIFEST", os.path.join(ROOT, "foundry", "MANIFEST.json"))
+LOG = os.path.join(os.path.dirname(MANIFEST), "LOG.md")
+CACHE = os.path.join(ROOT, ".foundry-cache")
+
+def die(msg): print(f"lift: ERROR: {msg}", file=sys.stderr); sys.exit(1)
+
+args = sys.argv[1:]
+opt = {"sha": "HEAD", "class": "verbatim", "actor": os.environ.get("USER", "unknown"), "dry_run": False}
+i = 0
+while i < len(args):
+    a = args[i]
+    if a == "--dry-run": opt["dry_run"] = True; i += 1; continue
+    if not a.startswith("--") or i + 1 >= len(args): die(f"bad argument: {a}")
+    opt[a[2:].replace("-", "_")] = args[i + 1]; i += 2
+for req in ("upstream", "path", "dest", "skill"):
+    if req not in opt: die(f"--{req} is required")
+if opt["class"] not in ("verbatim", "verbatim-minus", "distilled-source"):
+    die(f"unknown class: {opt['class']}")
+
+manifest = json.load(open(MANIFEST))
+up = manifest["upstreams"].get(opt["upstream"]) or die(f"unknown upstream: {opt['upstream']}")
+if not up.get("url"): die(f"upstream {opt['upstream']} has no URL (private source — use course-dropin.sh)")
+
+# --- cache clone, pinned fetch ---
+cachedir = os.path.join(CACHE, re.sub(r"[^A-Za-z0-9._-]", "_", opt["upstream"]))
+if not os.path.isdir(cachedir):
+    subprocess.run(["git", "clone", "--quiet", up["url"], cachedir], check=True)
+subprocess.run(["git", "-C", cachedir, "fetch", "--quiet", "origin"], check=True)
+sha = opt["sha"]
+if sha == "HEAD":
+    head = subprocess.run(["git", "-C", cachedir, "ls-remote", "origin", "HEAD"],
+                          capture_output=True, text=True, check=True).stdout.split()
+    sha = head[0]
+sha = subprocess.run(["git", "-C", cachedir, "rev-parse", f"{sha}^{{commit}}"],
+                     capture_output=True, text=True, check=True).stdout.strip()
+
+# --- extract blob at pinned SHA (bytes, never through a model) ---
+blob = subprocess.run(["git", "-C", cachedir, "show", f"{sha}:{opt['path']}"],
+                      capture_output=True, check=True).stdout
+digest = hashlib.sha256(blob).hexdigest()
+
+dest_abs = os.path.join(ROOT, opt["dest"])
+entry = {
+    "class": opt["class"], "upstream": opt["upstream"], "upstream_path": opt["path"],
+    "pinned_sha": sha, "sha256": digest, "lifted": date.today().isoformat(),
+    "skill": opt["skill"], "rulings": [],
+}
+
+if opt["dry_run"]:
+    print(f"lift: DRY RUN — would write {len(blob)} bytes to {opt['dest']}")
+    print(json.dumps({opt["dest"]: entry}, indent=2)); sys.exit(0)
+
+if opt["class"] != "distilled-source":
+    os.makedirs(os.path.dirname(dest_abs), exist_ok=True)
+    open(dest_abs, "wb").write(blob)
+if opt["class"] == "verbatim-minus":
+    pristine = os.path.join(os.path.dirname(MANIFEST), "pristine", opt["dest"].replace("/", "__"))
+    os.makedirs(os.path.dirname(pristine), exist_ok=True)
+    open(pristine, "wb").write(blob)
+    entry["pristine"] = os.path.relpath(pristine, ROOT)
+    entry["patch"] = entry["pristine"] + ".patch"
+    open(os.path.join(ROOT, entry["patch"]), "w").write("")  # authored next via make-patch.sh
+if opt["class"] == "distilled-source":
+    entry["class"] = "distilled"
+    entry["note"] = "source recorded; file content is authored — hash set by check-integrity --update-distilled"
+    entry.pop("sha256")
+
+manifest["files"][opt["dest"]] = entry
+json.dump(manifest, open(MANIFEST, "w"), indent=2); open(MANIFEST, "a").write("\n")
+with open(LOG, "a") as f:
+    f.write(f"- {date.today().isoformat()} · lift · {opt['actor']} · {opt['dest']} ← "
+            f"{opt['upstream']}:{opt['path']} @ {sha[:9]} · class={entry['class']} · sha256={digest[:12]}…\n")
+print(f"lift: OK · {opt['dest']} ← {opt['upstream']}:{opt['path']} @ {sha[:9]} · {entry['class']}")
+PYEOF

--- a/foundry/scripts/make-patch.sh
+++ b/foundry/scripts/make-patch.sh
@@ -1,0 +1,33 @@
+#!/usr/bin/env bash
+# make-patch.sh — record the cut for a verbatim-minus file.
+#
+# After lift.sh --class verbatim-minus (which stores the pristine copy and an
+# empty patch), edit the SHIPPED file to remove the sections being cut, then run
+# this to regenerate the patch and re-lock the hash. The cut itself is reviewed
+# as the patch diff.
+#
+# Usage: foundry/scripts/make-patch.sh <repo-path>
+set -euo pipefail
+REPO_ROOT="$(git -C "$(dirname "$0")" rev-parse --show-toplevel)"
+export REPO_ROOT
+exec python3 - "$@" <<'PYEOF'
+import hashlib, json, os, subprocess, sys
+from datetime import date
+ROOT = os.environ["REPO_ROOT"]
+MANIFEST = os.environ.get("FOUNDRY_MANIFEST", os.path.join(ROOT, "foundry", "MANIFEST.json"))
+LOG = os.path.join(os.path.dirname(MANIFEST), "LOG.md")
+manifest = json.load(open(MANIFEST))
+path = sys.argv[1]
+e = manifest["files"].get(path) or sys.exit(f"make-patch: no manifest entry for {path}")
+if e["class"] != "verbatim-minus": sys.exit(f"make-patch: {path} is class {e['class']}")
+r = subprocess.run(["diff", "-u", os.path.join(ROOT, e["pristine"]), os.path.join(ROOT, path)],
+                   capture_output=True, text=True)
+if r.returncode not in (0, 1): sys.exit(f"make-patch: diff failed: {r.stderr}")
+open(os.path.join(ROOT, e["patch"]), "w").write(r.stdout)
+h = hashlib.sha256(open(os.path.join(ROOT, path), "rb").read()).hexdigest()
+e["sha256"] = h
+json.dump(manifest, open(MANIFEST, "w"), indent=2); open(MANIFEST, "a").write("\n")
+with open(LOG, "a") as f:
+    f.write(f"- {date.today().isoformat()} · make-patch · {os.environ.get('USER','unknown')} · {path} · patch regenerated · sha256={h[:12]}…\n")
+print(f"make-patch: OK · {path} · patch {'empty (no cut yet)' if r.returncode == 0 else 'recorded'}")
+PYEOF


### PR DESCRIPTION
The factory before the products. This PR contains zero vendored content — it builds the machinery that all convergence work must flow through.

## What's here
- **foundry/MANIFEST.json** — provenance source of truth: 4 file classes, 8 upstreams with licenses, legacy references registered as `authored`
- **foundry/scripts/** — `lift.sh` (the only way vendored bytes enter; pins SHA, hashes, logs), `check-integrity.sh` (hash gate + verbatim-minus patch reproduction + references/ coverage), `make-patch.sh`, `course-dropin.sh` (local-only, refuses to run without the gitignore fence)
- **foundry/LEDGER.md** — 11 contradiction rulings seeded (L-01..L-11)
- **foundry/LOG.md** — append-only ops log
- **AGENTS.md / CLAUDE.md** — the always-on fence: five operating rules for any agent in this repo
- **.claude/skills/foundry/** — internal meta-skill (hidden from skills.sh consumers via `metadata.internal`) + 7 runbooks
- **.github/workflows/integrity.yml** — the gate, on every push and PR

## Verified
Smoke-tested end to end against real upstreams: verbatim lift (jakubkrehel/skills), verbatim-minus lift + patch cycle (emilkowalski/skills), and single-character tampering caught in both classes with a red exit.

Next: the `review` skill as the proving ground.

https://claude.ai/code/session_01ViYqEXvxmBrQJY7y29CVqc