### PR TITLE
README: cards as the index

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,107 +2,70 @@
 
 # product-engineering
 
-Five agent skills covering the end-to-end product design process, converged from the
-best published design-engineering skill work — with the source prose preserved
-**byte-for-byte** and proven by hashes.
-
-| Skill | The deliverable | Modes |
-| --- | --- | --- |
-| `pe-design` | documents & artifacts, before code | understand · direct · mock · vary · onboard |
-| `pe-build` | production UI code | craft · motion · a11y · harden |
-| `pe-review` | read-only findings & verdicts | change · screen · plans · guidelines · stress · motion · opportunities · a11y |
-| `pe-product-description` | a behavior-spec repo | (Steve Ruiz's skill, vendored whole) |
-| `pe-brand-assets` | standalone on-brand assets (SVG-first) | — |
-
-Each skill is a thin router over reference files preserved from graded sources —
-Emil Kowalski, Jakub Krehel, Julien Thibeaut, Vercel, Leon, plannotator, Steve Ruiz,
-Impeccable (see NOTICE).
-
-## Install
+Five agent skills covering the end-to-end product design process — for Claude Code
+and any agent that supports the [Agent Skills](https://agentskills.io) format.
+Converged from the best published design-engineering skill work, with the source
+prose preserved byte-for-byte and verified by hashes.
 
 ```bash
-npx skills add backnotprop/product-engineering            # all five
-npx skills add backnotprop/product-engineering --skill pe-review
+npx skills add backnotprop/product-engineering
 ```
 
-## Using the skills
+## The skills
 
-Install once. Say what you need — the right skill triggers on your words and routes
-itself to the right mode. The kit follows the product journey:
-**understand → shape → build → review**, plus two specialists.
+<p>
+  <a href="skills/pe-design"><img src="brand/cards/pe-design.svg" width="49%" alt="pe-design — Design it. Produces documents and artifacts, not production code. Modes: understand, direct, mock, vary, onboard."></a>
+  <a href="skills/pe-build"><img src="brand/cards/pe-build.svg" width="49%" alt="pe-build — Build it. Writes and refines code without changing the product's identity. Modes: craft, motion, a11y, harden."></a>
+</p>
+<p>
+  <a href="skills/pe-review"><img src="brand/cards/pe-review.svg" width="49%" alt="pe-review — Judge it. Reports findings and makes no edits. Modes: change, screen, plans, guidelines, stress, motion, a11y."></a>
+  <a href="skills/pe-product-description"><img src="brand/cards/pe-product-description.svg" width="49%" alt="pe-product-description — Describe it. What users see and do, verified against the running product."></a>
+</p>
+<p align="center">
+  <a href="skills/pe-brand-assets"><img src="brand/cards/pe-brand-assets.svg" width="49%" alt="pe-brand-assets — Brand it. Authors SVG from recorded brand values, not guesses."></a>
+</p>
 
-### 1 · Understand the product, set the direction
+Say what you need — the right skill triggers on your words and routes itself to the
+right mode. The skills hand off to each other by name: a finding from `pe-review`
+goes to `pe-build`; a winning variant from `pe-design` goes to `pe-build`. Enter the
+loop at any stage.
 
-| Say | Skill · mode | You get |
-| --- | --- | --- |
-| "Document our product and design system" | `pe-design` · understand | `PRODUCT.md` + `DESIGN.md` from repo evidence — or extracted from a public URL |
-| "We're greenfield — generate a design system" | `pe-design` · understand | A generated system, labeled chosen-not-observed |
-| "How should this look and feel?" | `pe-design` · direct | A creative direction derived from your subject, checked against the AI-slop tells |
+<details>
+<summary><b>Examples — what to say, what you get</b></summary>
+<br>
 
-### 2 · Shape it before code
+| You say | You get |
+| --- | --- |
+| "Document our design system" | `pe-design` writes `PRODUCT.md` + `DESIGN.md` from repo evidence, or from a public URL |
+| "How should this look and feel?" | `pe-design` derives a creative direction from your subject |
+| "Wireframe the settings flow" | `pe-design` builds self-contained HTML, wireframe through prototype |
+| "Show me three takes on this card" | `pe-design` renders real variants behind a picker in your page |
+| "Build the pricing card" · "polish this" | `pe-build` writes production code at the craft bar |
+| "Animate the drawer" · "this feels janky" | `pe-build`, motion mode |
+| "Get this ready for production" | `pe-build` hardens: data extremes, failure states, devices, metadata |
+| "Review my PR" | `pe-review`, diff-scoped and read-only |
+| "Audit the app, give me a roadmap" | `pe-review` emits plans another agent can execute |
+| "Write a product description for the editor" | `pe-product-description` builds a verified behavior spec |
+| "Make an SVG header image for this post" | `pe-brand-assets` authors it from your recorded brand values |
 
-| Say | Skill · mode | You get |
-| --- | --- | --- |
-| "Wireframe the settings flow" | `pe-design` · mock | Self-contained HTML at the right fidelity: wireframe → mockup → prototype |
-| "Show me three takes on this card" | `pe-design` · vary | Genuinely different variants behind a picker in your real page; promote the winner |
-| "Users bail during setup" | `pe-design` · onboard | An activation flow: empty states, checklists, the lightest pattern that teaches |
+</details>
 
-### 3 · Build it
+## How it stays honest
 
-| Say | Skill · mode | You get |
-| --- | --- | --- |
-| "Build the pricing card" · "polish this" | `pe-build` · craft | Production code at the craft bar: spacing, type, color, copy, states |
-| "Animate the drawer" · "this feels janky" | `pe-build` · motion | Motion built to exact values, gestures included |
-| "Make this table keyboard-accessible" | `pe-build` · a11y | Implemented accessibility: keyboard, screen readers, focus, forms |
-| "Get this ready for production" | `pe-build` · harden | Data extremes, failure states, devices, languages, offline, metadata |
+Most of this kit is other authors' work, carried byte-for-byte: every vendored file
+is pinned to an upstream commit and hash-locked in `foundry/MANIFEST.json`, and CI
+fails if a single character drifts. Recorded cuts live as patches beside pristine
+copies; where sources disagreed, the ruling is written down once in a ledger; a
+weekly watcher compares every pin against upstream and opens an issue when an author
+improves something we carry.
 
-### 4 · Judge it — read-only, findings never edits
-
-| Say | Skill · mode | You get |
-| --- | --- | --- |
-| "Review my PR" | `pe-review` · change | Diff-scoped review; introduced vs pre-existing, classified |
-| "Review this screen" | `pe-review` · screen | The full two-pass critique with scored rubrics |
-| "Audit the app, give me a roadmap" | `pe-review` · plans | Findings as self-contained plans another agent can execute |
-| "Will this survive real data?" | `pe-review` · stress | The component rendered in every hostile state |
-
-Also modes of `pe-review`: guidelines check ("check against best practices"),
-animation review, a11y audit.
-
-### Anytime · the specialists
-
-| Say | Skill | You get |
-| --- | --- | --- |
-| "Write a product description for the editor" | `pe-product-description` | A behavior-spec repo — what users see, can do, and what exactly happens — verified against the running product |
-| "Make an SVG header image for this post" | `pe-brand-assets` | On-brand SVG (PNG exported where destinations need it); it reads your brand truth first and refuses to invent it |
-
-**Skills hand off by name.** A review's findings go to pe-build. A winning variant
-goes to pe-build. Hardening verifies through pe-review. Enter the loop at any stage.
-
-## How this repo works
-
-- **`foundry/MANIFEST.json`** records every non-authored file's upstream repo, path,
-  pinned commit, and sha256. CI (`integrity.yml`) recomputes every hash on every
-  push — a single reworded character in a vendored file fails the build.
-- **Cuts are recorded, never silent**: files trimmed from their source
-  (`verbatim-minus`) keep a pristine copy plus a `.patch` in `foundry/pristine/`;
-  CI proves pristine + patch reproduces the shipped file.
-- **`foundry/LEDGER.md`** holds the rulings where sources contradicted each other;
-  no text in the kit may disagree with an active ruling.
-- **`foundry/derivations/`** are the per-skill receipts: what was lifted, cut,
-  distilled, and why. **`foundry/LOG.md`** is the append-only history.
-- **`upstream-watch.yml`** runs weekly: it diffs every pinned upstream blob against
-  upstream HEAD and opens an issue when authors improve something we vendored.
-- Bytes enter this repo only through `foundry/scripts/lift.sh` — LLM agents working
-  here never retype vendored prose (see AGENTS.md, the fence).
-
-The animations.dev course pack is **not** in this repo — purchasers layer it locally
-via `foundry/scripts/course-dropin.sh` into gitignored folders, and the build skill
-prefers it when present.
+The machinery, runbooks, and per-skill receipts live in [`foundry/`](foundry/).
+Attribution is in [`NOTICE`](NOTICE). The animations.dev course pack is not
+distributed here — owners layer it in locally via `foundry/scripts/course-dropin.sh`.
 
 <img src="brand/credits.svg" alt="Built from the work of Emil Kowalski, Jakub Krehel, Julien Thibeaut, Plannotator, Vercel, Leon, Steve Ruiz, Impeccable — preserved byte-for-byte, hash-verified" width="100%">
 
 ## License
 
 Apache-2.0 for this repository's own work; vendored files remain under their
-authors' licenses with provenance in `foundry/MANIFEST.json` and attribution in
-`NOTICE`.
+authors' licenses, with per-file provenance in `foundry/MANIFEST.json`.

--- a/foundry/LOG.md
+++ b/foundry/LOG.md
@@ -149,3 +149,4 @@ manual events. Never edit or delete existing lines.
 - 2026-08-26 · brand · claude · scope correction: the de-slogan pass overreached — the approved verb headlines (Design it. / Build it. / Judge it.) were replaced without instruction; restored. Sentence fixes stand. DESIGN.md records the boundary: headlines are the chosen voice, the writing bar governs sentences
 - 2026-08-26 · brand · claude · redundancy pass: Describe it./Documents… verb repetition removed from the pe-product-description card; headline+sentence pairs verified non-overlapping across all five
 - 2026-08-26 · brand · claude+ramos · Plannotator added to the credits card (was in NOTICE and MANIFEST but omitted from the card; card now matches the record)
+- 2026-08-26 · docs · claude+ramos · README redesigned: skill cards as the linked index (paired 49% grid), say/get examples folded into a collapsible, machinery detail moved to foundry/README.md, prose cut to the SEO-and-comprehension minimum

--- a/foundry/README.md
+++ b/foundry/README.md
@@ -1,0 +1,45 @@
+# The foundry
+
+The machinery that builds and maintains the kit. The main README states the promise;
+this directory proves it.
+
+## Provenance model
+
+Every file in the kit belongs to exactly one class, recorded in `MANIFEST.json`:
+
+| Class | Meaning | Integrity check |
+| --- | --- | --- |
+| `verbatim` | byte-for-byte lift from a pinned upstream commit | sha256 vs manifest, and disk bytes vs the upstream blob at the pin (watcher) |
+| `verbatim-minus` | verbatim with a recorded cut | patch applied to the pristine copy in `pristine/` must reproduce the shipped file |
+| `distilled` | authored condensation of a recorded source | sha256 vs manifest; updated only via the distill runbook |
+| `authored` | ours | normal review |
+
+Bytes enter the repo only through `scripts/lift.sh`, which extracts the blob from
+the upstream git object, records the pin and hash, and appends to `LOG.md`. Agents
+working in this repo never retype vendored prose (see the repo's `AGENTS.md`).
+
+## Verification
+
+- `scripts/check-integrity.sh` runs in CI on every push and PR: recomputes every
+  hash, re-applies every patch against pristine, and fails if any file under a
+  skill's `references/` is unclassified.
+- `scripts/check-upstream.sh` runs weekly (`upstream-watch.yml`): compares each
+  pinned upstream blob against upstream HEAD, verifies disk bytes against the pin
+  independently of the manifest (TAMPER), and opens one summary issue on drift.
+- Drift is classified by the runbooks, never auto-merged.
+
+## Records
+
+- `MANIFEST.json` — per-file provenance: upstream, path, pinned commit, sha256.
+- `LEDGER.md` — the rulings where sources contradicted each other; binding on all
+  skill text until superseded.
+- `derivations/` — per-skill receipts: what was lifted, cut, distilled, and why.
+- `LOG.md` — append-only history of every lift, patch, ruling, and incident.
+- `pristine/` — untouched originals and their patches for `verbatim-minus` files.
+
+## Operating it
+
+The process itself is a skill: `.claude/skills/foundry/` loads for any agent session
+in this repo and carries the seven runbooks (lift, re-lift, distill refresh, new
+ruling, integrity failure, course drop-in, new skill). The division of labor is
+fixed: agents propose, hashes verify, humans merge.


### PR DESCRIPTION
Skill cards become the linked index (2-up pairs, last centered), examples fold into a collapsible, machinery detail moves to foundry/README.md. Text on first screen cut by roughly two-thirds; everything in an image also exists as text. https://claude.ai/code/session_01ViYqEXvxmBrQJY7y29CVqc