### PR TITLE
product-engineering: lazy-entry router

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,8 @@ npx skills add backnotprop/product-engineering
 </p>
 
 Say what you need — the right skill triggers on your words and routes itself to the
-right mode. The skills hand off to each other by name: a finding from `pe-review`
+right mode. Or use the lazy entry: start any request with "product engineering" and
+the `product-engineering` router picks the skill for you. The skills hand off to each other by name: a finding from `pe-review`
 goes to `pe-build`; a winning variant from `pe-design` goes to `pe-build`. Enter the
 loop at any stage.
 
@@ -52,6 +53,7 @@ loop at any stage.
 
 | Skill | What it does |
 | --- | --- |
+| [`product-engineering`](skills/product-engineering) | The router: say "product engineering, ..." and it dispatches to the right skill below |
 | [`pe-design`](skills/pe-design) | Product and design-system context (`PRODUCT.md`, `DESIGN.md`), creative direction, HTML wireframes and prototypes, UI variants, onboarding flows |
 | [`pe-build`](skills/pe-build) | Production UI code: component craft, animation and gestures, accessibility, production hardening |
 | [`pe-review`](skills/pe-review) | Read-only UI review: PR/diff review, screen critique, audits with executable plans, guidelines checks, stress tests |

--- a/foundry/LOG.md
+++ b/foundry/LOG.md
@@ -153,3 +153,4 @@ manual events. Never edit or delete existing lines.
 - 2026-08-26 · docs · claude+ramos · virtue-framing removed: 'How it stays honest' → 'Provenance and integrity'; foundry README's promise/prove line replaced with a factual description
 - 2026-08-26 · docs · claude+ramos · crawlable skill index added under the examples: linked names + one-line keyword-bearing definitions (SVG cards are weak search signal; the table is the indexable record)
 - 2026-08-26 · brand · claude+ramos · card sentences rewritten as positive deliverable statements (every sentence had been a caveat or negative definition); DESIGN.md rule updated: boundaries live in the skills, never in the copy
+- 2026-08-26 · build-skill · claude+ramos · skills/product-engineering created: the lazy-entry router (authored only, no lifts) — routes by deliverable, defers to the owning skill; skills.sh.json and README updated

--- a/foundry/derivations/product-engineering.md
+++ b/foundry/derivations/product-engineering.md
@@ -1,0 +1,7 @@
+# Derivation: product-engineering
+
+The lazy entry: a fully-spelled-out router skill. Invoked as "product engineering,
+<anything>", it reads the request and dispatches to the right pe-* skill and mode,
+then follows that skill. No vendored content — authored spine only, no references.
+Routing logic reuses the deliverable axis already stated in each skill's description;
+the router points and defers, it never does the work from its own summary.

--- a/skills.sh.json
+++ b/skills.sh.json
@@ -6,6 +6,7 @@
       "title": "Converged Skills",
       "description": "The product-engineering kit: five converged skills, each a thin router over byte-preserved references from graded sources.",
       "skills": [
+        "product-engineering",
         "pe-design",
         "pe-build",
         "pe-review",

--- a/skills/product-engineering/SKILL.md
+++ b/skills/product-engineering/SKILL.md
@@ -1,0 +1,41 @@
+---
+name: product-engineering
+description: The front door to the product-engineering kit. Use when the user says "product engineering" followed by any product, design, UI, review, or asset request; when they ask which pe-* skill fits a task; or when a product task doesn't clearly match one skill. Routes to pe-design, pe-build, pe-review, pe-product-description, or pe-brand-assets and then follows that skill. If a request already names or clearly matches a specific pe-* skill, that skill takes it directly — this router yields.
+license: Apache-2.0
+metadata:
+  provenance: foundry/derivations/product-engineering.md in the source repository
+---
+
+# Product Engineering
+
+Route, then defer. Decide which skill owns the request, read that skill's SKILL.md,
+and follow it completely. Never do the work from this file's summaries.
+
+## Route by the deliverable
+
+Ask what should exist when the work is done:
+
+| The user wants | Route to |
+| --- | --- |
+| A document or design artifact — context docs, a direction, wireframes, mockups, prototypes, variants, an onboarding flow | `pe-design` |
+| Working production code — a component built, polished, animated, made accessible, or hardened; a UI bug fixed | `pe-build` |
+| A judgment on what exists — a review, critique, audit, or stress test of a screen, diff, or PR | `pe-review` |
+| A behavior spec — documentation of what users see and do, verified against the product | `pe-product-description` |
+| A standalone asset — an illustration, social/OG image, or logo in the project's brand | `pe-brand-assets` |
+
+## Disambiguation
+
+- **Verb beats noun.** "Review the animation" → `pe-review`. "Fix the animation" →
+  `pe-build`.
+- **A named diff, branch, or PR** always means `pe-review`, change mode.
+- **A bug in UI behavior** is code to fix → `pe-build`. If the user only wants to
+  know what's wrong, not a fix → `pe-review`.
+- **A mockup of something new** → `pe-design`. **N takes on one existing piece** →
+  `pe-design`, vary mode.
+- Still ambiguous after that: ask one short question naming the two candidate
+  skills, then proceed.
+
+## After routing
+
+State the choice in one line ("Routing to pe-build, motion mode"), load that skill,
+and follow its contract — including its handoffs back to the other skills.


### PR DESCRIPTION
The fully-spelled-out front door: routes by deliverable, defers to the owning skill, asks one question only when genuinely ambiguous. Authored-only; receipts in foundry/derivations/product-engineering.md. https://claude.ai/code/session_01ViYqEXvxmBrQJY7y29CVqc