### PR TITLE
router: brief mode coverage

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,6 +33,7 @@ npx skills add backnotprop/product-engineering
 | --- | --- |
 | "Document our design system" | `pe-design` writes `PRODUCT.md` + `DESIGN.md` from repo evidence, or from a public URL |
 | "How should this look and feel?" | `pe-design` derives a creative direction from your subject |
+| "Write a brief for the checkout flow" | `pe-design` interviews you, then returns a confirmed one-feature design brief |
 | "Wireframe the settings flow" | `pe-design` builds self-contained HTML, wireframe through prototype |
 | "Show me three takes on this card" | `pe-design` renders real variants behind a picker in your page |
 | "Build the pricing card" · "polish this" | `pe-build` writes production code at the craft bar |

--- a/foundry/LOG.md
+++ b/foundry/LOG.md
@@ -166,3 +166,4 @@ manual events. Never edit or delete existing lines.
 - 2026-08-25 · distill-update · ramos · skills/pe-design/references/brief/index.md · sha256=d583774250b9…
 - 2026-08-26 · adversarial-review · claude · brief-mode fixes: Redesign authority state restored with its preservation duties (had been dissolved into no-authority — derivation claim was false), understand now states its side of the boundary with a pointer to brief mode, spine sequence corrected (direct runs mid-flow, not first), handoff restatement removed from the reference (spine owns handoffs and now names the confirmed brief)
 - 2026-08-26 · brand · ramos · pe-design card mode line updated for brief mode (six modes); camo cache busted
+- 2026-08-26 · docs · ramos · router gains the brief deliverable + the new-vs-existing spec disambiguation (pe-design brief vs pe-product-description); README examples gain a brief row

--- a/skills/product-engineering/SKILL.md
+++ b/skills/product-engineering/SKILL.md
@@ -17,7 +17,7 @@ Ask what should exist when the work is done:
 
 | The user wants | Route to |
 | --- | --- |
-| A document or design artifact — context docs, a direction, wireframes, mockups, prototypes, variants, an onboarding flow | `pe-design` |
+| A document or design artifact — context docs, a design brief for one feature, a direction, wireframes, mockups, prototypes, variants, an onboarding flow | `pe-design` |
 | Working production code — a component built, polished, animated, made accessible, or hardened; a UI bug fixed | `pe-build` |
 | A judgment on what exists — a review, critique, audit, or stress test of a screen, diff, or PR | `pe-review` |
 | A behavior spec — documentation of what users see and do, verified against the product | `pe-product-description` |
@@ -30,6 +30,8 @@ Ask what should exist when the work is done:
 - **A named diff, branch, or PR** always means `pe-review`, change mode.
 - **A bug in UI behavior** is code to fix → `pe-build`. If the user only wants to
   know what's wrong, not a fix → `pe-review`.
+- **A spec or plan for something new** — a feature not yet built → `pe-design`, brief
+  mode. **A spec of how the existing product behaves** → `pe-product-description`.
 - **A mockup of something new** → `pe-design`. **N takes on one existing piece** →
   `pe-design`, vary mode.
 - Still ambiguous after that: ask one short question naming the two candidate


### PR DESCRIPTION
The router's deliverable table now names the design brief, and the spec collision (new feature vs existing behavior) gets an explicit disambiguation. One example row added to the README. https://claude.ai/code/session_01ViYqEXvxmBrQJY7y29CVqc